### PR TITLE
Add init command for system setup

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/adi-Roth/flactanCLI/internal/system"
+	"github.com/adi-Roth/flactanCLI/internal/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -18,48 +19,39 @@ type Config struct {
 	ToolsPath string `yaml:"tools-path"`
 }
 
-// initCmd represents the "init" command
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize FlactanCLI and create configuration files",
-	Long: `The "init" command collects system information, checks internet connectivity, 
-and sets up necessary configuration files in $HOME/.flactancli/.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		initializeConfig()
-	},
-}
+// InitializeConfig now takes a FileSystem interface (for mocking in tests)
+func InitializeConfig(fs utils.FileSystem, customDir string) {
+	// Use customDir in tests, otherwise use $HOME/.flactancli
+	var configDir string
+	if customDir != "" {
+		configDir = customDir
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Println("Error getting user home directory:", err)
+			os.Exit(1)
+		}
+		configDir = filepath.Join(homeDir, ".flactancli")
+	}
 
-// initializeConfig performs the setup tasks
-func initializeConfig() {
-	// Get OS details
+	configPath := filepath.Join(configDir, "config.yaml")
+	toolsPath := filepath.Join(configDir, "tools.yaml")
+
+	// Ensure the directory exists
+	if err := fs.MkdirAll(configDir, 0755); err != nil {
+		fmt.Println("Error creating config directory:", err)
+		os.Exit(1)
+	}
+
+	// Get system information
 	osName, osVersion := system.GetOSInfo()
-	fmt.Printf("Detected OS: %s %s\n", osName, osVersion)
-
-	// Check internet connectivity
 	isConnected := system.CheckInternet()
 	internetStatus := "offline"
 	if isConnected {
 		internetStatus = "connected"
 	}
-	fmt.Printf("Internet Status: %s\n", internetStatus)
 
-	// Define config file path
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Println("Error getting user home directory:", err)
-		os.Exit(1)
-	}
-	configDir := filepath.Join(homeDir, ".flactancli")
-	configPath := filepath.Join(configDir, "config.yaml")
-	toolsPath := filepath.Join(configDir, "tools.yaml")
-
-	// Ensure the directory exists
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		fmt.Println("Error creating config directory:", err)
-		os.Exit(1)
-	}
-
-	// Create config.yaml file
+	// Create config file
 	config := Config{
 		OSName:    osName,
 		OSVersion: osVersion,
@@ -72,7 +64,7 @@ func initializeConfig() {
 		os.Exit(1)
 	}
 
-	if err := os.WriteFile(configPath, configData, 0644); err != nil {
+	if err := fs.WriteFile(configPath, configData, 0644); err != nil {
 		fmt.Println("Error writing config.yaml:", err)
 		os.Exit(1)
 	}
@@ -80,13 +72,23 @@ func initializeConfig() {
 	fmt.Println("Configuration saved:", configPath)
 
 	// Create an empty tools.yaml file if it doesn't exist
-	if _, err := os.Stat(toolsPath); os.IsNotExist(err) {
-		if err := os.WriteFile(toolsPath, []byte{}, 0644); err != nil {
+	_, err = fs.ReadFile(toolsPath)
+	if err != nil { // If file doesn't exist, write it
+		if err := fs.WriteFile(toolsPath, []byte{}, 0644); err != nil {
 			fmt.Println("Error creating tools.yaml:", err)
 			os.Exit(1)
 		}
 		fmt.Println("Tools configuration initialized:", toolsPath)
 	}
+}
+
+// initCmd represents the "init" command
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize FlactanCLI and create configuration files",
+	Run: func(cmd *cobra.Command, args []string) {
+		InitializeConfig(utils.OSFileSystem{}, "") // Use real filesystem in production
+	},
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/adi-Roth/flactanCLI/internal/system"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// Config structure for storing system information
+type Config struct {
+	OSName    string `yaml:"os-name"`
+	OSVersion string `yaml:"os-version"`
+	Internet  string `yaml:"internet"`
+	ToolsPath string `yaml:"tools-path"`
+}
+
+// initCmd represents the "init" command
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize FlactanCLI and create configuration files",
+	Long: `The "init" command collects system information, checks internet connectivity, 
+and sets up necessary configuration files in $HOME/.flactancli/.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		initializeConfig()
+	},
+}
+
+// initializeConfig performs the setup tasks
+func initializeConfig() {
+	// Get OS details
+	osName, osVersion := system.GetOSInfo()
+	fmt.Printf("Detected OS: %s %s\n", osName, osVersion)
+
+	// Check internet connectivity
+	isConnected := system.CheckInternet()
+	internetStatus := "offline"
+	if isConnected {
+		internetStatus = "connected"
+	}
+	fmt.Printf("Internet Status: %s\n", internetStatus)
+
+	// Define config file path
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println("Error getting user home directory:", err)
+		os.Exit(1)
+	}
+	configDir := filepath.Join(homeDir, ".flactancli")
+	configPath := filepath.Join(configDir, "config.yaml")
+	toolsPath := filepath.Join(configDir, "tools.yaml")
+
+	// Ensure the directory exists
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		fmt.Println("Error creating config directory:", err)
+		os.Exit(1)
+	}
+
+	// Create config.yaml file
+	config := Config{
+		OSName:    osName,
+		OSVersion: osVersion,
+		Internet:  internetStatus,
+		ToolsPath: toolsPath,
+	}
+	configData, err := yaml.Marshal(&config)
+	if err != nil {
+		fmt.Println("Error marshaling config data:", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(configPath, configData, 0644); err != nil {
+		fmt.Println("Error writing config.yaml:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Configuration saved:", configPath)
+
+	// Create an empty tools.yaml file if it doesn't exist
+	if _, err := os.Stat(toolsPath); os.IsNotExist(err) {
+		if err := os.WriteFile(toolsPath, []byte{}, 0644); err != nil {
+			fmt.Println("Error creating tools.yaml:", err)
+			os.Exit(1)
+		}
+		fmt.Println("Tools configuration initialized:", toolsPath)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/adi-Roth/flactanCLI
 go 1.24.0
 
 require (
+	bou.ke/monkey v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,6 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/system/network.go
+++ b/internal/system/network.go
@@ -1,0 +1,15 @@
+package system
+
+import (
+	"net/http"
+	"time"
+)
+
+// CheckInternet verifies if the system has internet access
+func CheckInternet() bool {
+	client := http.Client{
+		Timeout: 2 * time.Second,
+	}
+	_, err := client.Get("https://www.google.com")
+	return err == nil
+}

--- a/internal/system/os_info.go
+++ b/internal/system/os_info.go
@@ -1,0 +1,10 @@
+package system
+
+import (
+	"runtime"
+)
+
+// GetOSInfo returns the OS name and version
+func GetOSInfo() (string, string) {
+	return runtime.GOOS, runtime.GOARCH
+}

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -1,0 +1,28 @@
+package utils
+
+import "os"
+
+// FileSystem defines an interface for file operations (to enable mocking)
+type FileSystem interface {
+	MkdirAll(path string, perm os.FileMode) error
+	WriteFile(filename string, data []byte, perm os.FileMode) error
+	ReadFile(filename string) ([]byte, error)
+}
+
+// OSFileSystem is the real implementation for actual file operations
+type OSFileSystem struct{}
+
+// MkdirAll creates directories
+func (OSFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// WriteFile writes data to a file
+func (OSFileSystem) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(filename, data, perm)
+}
+
+// ReadFile reads a file's content
+func (OSFileSystem) ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}

--- a/tests/cmd/init_test.go
+++ b/tests/cmd/init_test.go
@@ -1,0 +1,60 @@
+package cmd_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/adi-Roth/flactanCLI/cmd"
+	"github.com/adi-Roth/flactanCLI/internal/system"
+	"github.com/adi-Roth/flactanCLI/tests/mocks"
+	"gopkg.in/yaml.v2"
+)
+
+// Config structure matching the one in init.go
+type Config struct {
+	OSName    string `yaml:"os-name"`
+	OSVersion string `yaml:"os-version"`
+	Internet  string `yaml:"internet"`
+	ToolsPath string `yaml:"tools-path"`
+}
+
+// TestInitCommand verifies that the init command correctly generates config files
+func TestInitCommand(t *testing.T) {
+	mockFS := &mocks.MockFileSystem{}
+
+	// Create a temporary test directory
+	tempDir, err := os.MkdirTemp("", "flactancli-test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary test directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Run init function with mock filesystem and test directory
+	cmd.InitializeConfig(mockFS, tempDir)
+
+	// Check if config.yaml exists
+	configData, err := mockFS.ReadFile(tempDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("Expected config.yaml to be created, but it does not exist")
+	}
+
+	// Read and parse config.yaml
+	var config Config
+	if err := yaml.Unmarshal(configData, &config); err != nil {
+		t.Fatalf("Failed to parse config.yaml: %v", err)
+	}
+
+	// Verify OS information
+	expectedOS, expectedVersion := system.GetOSInfo()
+	if config.OSName != expectedOS {
+		t.Errorf("Expected OSName to be %s, got %s", expectedOS, config.OSName)
+	}
+	if config.OSVersion != expectedVersion {
+		t.Errorf("Expected OSVersion to be %s, got %s", expectedVersion, config.OSVersion)
+	}
+
+	// Check if tools.yaml exists
+	if _, err := mockFS.ReadFile(tempDir + "/tools.yaml"); err != nil {
+		t.Fatalf("Expected tools.yaml to be created, but it does not exist")
+	}
+}

--- a/tests/mocks/filesystem_mock.go
+++ b/tests/mocks/filesystem_mock.go
@@ -1,0 +1,38 @@
+package mocks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// MockFileSystem simulates file system operations for testing
+type MockFileSystem struct {
+	Files map[string][]byte // Simulated in-memory file storage
+}
+
+// MkdirAll simulates creating directories (always succeeds)
+func (fs *MockFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	fmt.Println("[MOCK] Creating directory:", path)
+	return nil
+}
+
+// WriteFile simulates writing files
+func (fs *MockFileSystem) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	if fs.Files == nil {
+		fs.Files = make(map[string][]byte)
+	}
+	fmt.Println("[MOCK] Writing file:", filename)
+	fs.Files[filename] = data
+	return nil
+}
+
+// ReadFile simulates reading files
+func (fs *MockFileSystem) ReadFile(filename string) ([]byte, error) {
+	if data, exists := fs.Files[filename]; exists {
+		fmt.Println("[MOCK] Reading file:", filename)
+		return data, nil
+	}
+	fmt.Println("[MOCK] File not found:", filename)
+	return nil, &os.PathError{Op: "open", Path: filename, Err: errors.New("no such file or directory")}
+}

--- a/tests/system/network_test.go
+++ b/tests/system/network_test.go
@@ -1,0 +1,17 @@
+package system_test
+
+import (
+	"testing"
+
+	"github.com/adi-Roth/flactanCLI/internal/system"
+)
+
+// Test CheckInternet function
+func TestCheckInternet(t *testing.T) {
+	// We can't guarantee network availability, so just check if it returns a boolean
+	isConnected := system.CheckInternet()
+
+	if isConnected != true && isConnected != false {
+		t.Errorf("Expected CheckInternet() to return true or false, got %v", isConnected)
+	}
+}

--- a/tests/system/os_info_test.go
+++ b/tests/system/os_info_test.go
@@ -1,0 +1,19 @@
+package system_test
+
+import (
+	"testing"
+
+	"github.com/adi-Roth/flactanCLI/internal/system"
+)
+
+// Test GetOSInfo function
+func TestGetOSInfo(t *testing.T) {
+	osName, osVersion := system.GetOSInfo()
+
+	if osName == "" {
+		t.Errorf("Expected a valid OS name, got an empty string")
+	}
+	if osVersion == "" {
+		t.Errorf("Expected a valid OS version, got an empty string")
+	}
+}


### PR DESCRIPTION
- Implemented `init` command to collect OS info and check internet connectivity.
- Created a config file at `$HOME/.flactancli/config.yaml`.
- Ensured tools.yaml is initialized properly.
- Added unit tests in `tests/cmd/`.
- Mocked filesystem operations to prevent real file modifications.
- Updated Makefile to run tests via `make test`.